### PR TITLE
fix bug with inlining scripts when webpack asset hash contains public path prefix

### DIFF
--- a/lib/elements.js
+++ b/lib/elements.js
@@ -41,9 +41,7 @@ const updateScriptElement = (compilation, options, tag) => {
 const isInline = (options, tag) => matches(tag.attributes.src, options.inline.test);
 
 const replaceWithInlineElement = (compilation, tag) => {
-  const scriptName = getScriptName(tag);
-  const asset = compilation.assets[scriptName];
-  if (!asset) throw new Error(`${CONSTANTS.PLUGIN}: no asset with href '${scriptName}'`);
+  const asset = getAsset(compilation, tag);
   const newTag = {
     tagName: 'script',
     closeTag: true,
@@ -53,13 +51,17 @@ const replaceWithInlineElement = (compilation, tag) => {
   return newTag;
 };
 
-const getScriptName = (tag) => {
+const getAsset = (compilation, tag) => {
   let scriptName = getRawScriptName(tag);
   // remove publicPath prefix
   if (scriptName.includes('/')) {
     scriptName = scriptName.replace(CONSTANTS.PUBLIC_PATH_PREFIX, '');
   }
-  return scriptName;
+  // find asset key, regardless of how it's prefixed
+  const scriptKey = Object.keys(compilation.assets).find(asset => asset.match(`${scriptName}$`));
+  if (!scriptKey) throw new Error(`${CONSTANTS.PLUGIN}: no asset with href '${scriptName}'`);
+  
+  return compilation.assets[scriptKey];
 };
 
 const getRawScriptName = (tag) => tag.attributes.src;


### PR DESCRIPTION
Some versions of Webpack have a compilation asset object of {'app.chunkHash.js': VALUE},
some have {'publicPath/app.chunkHash.js': VALUE}. Prior to this commit, the plugin
looked at a script tag's src value, stripped all prefixes from the asset's name, and
used that prefix-free name to directly reference the object in the compilation asset
object. This worked for prefix-free hashes but did not work when the asset object
contained the public path prefix.

This patch instead searches the asset object's keys for one which ends with the asset
name and uses that key to reference the asset; this accomodates both forms.